### PR TITLE
patch: fix device if fn

### DIFF
--- a/src-tauri/src/device.rs
+++ b/src-tauri/src/device.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 #[cfg(target_os = "windows")]
 pub fn get_device_id() -> String {
     let output = Command::new("wmic")
-        .args(["csproduct", "get", "uuid"])
+        .args(["os", "get", "serialnumber"])
         .creation_flags(0x08000000)
         .output()
         .expect("Failed to execute wmic command");
@@ -29,16 +29,16 @@ pub fn get_device_id() -> String {
 
 #[cfg(target_os = "macos")]
 pub fn get_device_id() -> String {
-    let output = Command::new("ioreg")
-        .args(["-d2", "-c", "IOPlatformExpertDevice"])
+    let output = Command::new("system_profiler")
+        .args(["SPHardwareDataType"])
         .output()
-        .expect("Failed to execute ioreg command");
+        .expect("Failed to execute system_profiler command");
 
     let output_str = String::from_utf8_lossy(&output.stdout);
     output_str
         .lines()
-        .find(|line| line.contains("IOPlatformUUID"))
-        .and_then(|line| line.split('"').nth(3))
+        .find(|line| line.contains("Serial Number"))
+        .and_then(|line| line.split_whitespace().nth(3))
         .unwrap_or("unknown")
         .to_string()
 }

--- a/src-tauri/src/device.rs
+++ b/src-tauri/src/device.rs
@@ -1,7 +1,9 @@
-use std::process::Command;
-
 #[cfg(target_os = "windows")]
+use std::process::Command;
 use std::os::windows::process::CommandExt;
+
+#[cfg(target_os = "macos")]
+use std::process::Command;
 
 #[cfg(target_os = "windows")]
 pub fn get_device_id() -> String {


### PR DESCRIPTION
This pull request includes changes to the `src-tauri/src/device.rs` file to update the way device IDs are retrieved for both Windows and macOS platforms. The changes ensure that the correct system commands are used for each operating system and improve the reliability of the device ID retrieval process.

Updates to device ID retrieval:

* [`src-tauri/src/device.rs`](diffhunk://#diff-193bfbe3613d6f38cdfce561f92982709994a299ed1eb1ce10c7f193372acf85L1-R11): Modified the command used to retrieve the device ID on Windows from `wmic csproduct get uuid` to `wmic os get serialnumber` and adjusted the arguments accordingly.
* [`src-tauri/src/device.rs`](diffhunk://#diff-193bfbe3613d6f38cdfce561f92982709994a299ed1eb1ce10c7f193372acf85L30-R41): Changed the command used to retrieve the device ID on macOS from `ioreg -d2 -c IOPlatformExpertDevice` to `system_profiler SPHardwareDataType` and modified the parsing logic to extract the serial number.