### PR TITLE
patch: fix macos implementation

### DIFF
--- a/src-tauri/src/device.rs
+++ b/src-tauri/src/device.rs
@@ -1,6 +1,5 @@
 #[cfg(target_os = "windows")]
-use std::process::Command;
-use std::os::windows::process::CommandExt;
+use { std::process::Command, std::os::windows::process::CommandExt };
 
 #[cfg(target_os = "macos")]
 use std::process::Command;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,6 +30,11 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "installerIcon": "icons/icon.ico"
+      }
+    }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "bruma",
+  "productName": "Bruma",
   "version": "0.1.0",
   "identifier": "com.bruma.app",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "bruma",
+        "title": "Bruma",
         "width": 800,
         "height": 600
       }


### PR DESCRIPTION
This pull request includes changes to the `src-tauri/tauri.conf.json` file to correct the product name capitalization and add a new configuration for the Windows installer icon.

Configuration updates:

* Changed the `productName` from "bruma" to "Bruma".
* Updated the window title to "Bruma" instead of "bruma".
* Added a new configuration for the Windows installer icon under `nsis`.